### PR TITLE
Allow writing and reading Prelogin messages with custom packet type

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -119,7 +119,7 @@ func (w *TdsBuffer) BeginPacket(packetType packetType, resetSession bool) {
 	if resetSession {
 		switch packetType {
 		// Reset session can only be set on the following packet types.
-		case packSQLBatch, packRPCRequest, packTransMgrReq:
+		case PackSQLBatch, PackRPCRequest, PackTransMgrReq:
 			status = 0x8
 		}
 	}

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -146,7 +146,7 @@ func (b *Bulk) sendBulkCommand(ctx context.Context) (err error) {
 	b.headerSent = true
 
 	var buf = b.cn.sess.buf
-	buf.BeginPacket(packBulkLoadBCP, false)
+	buf.BeginPacket(PackBulkLoadBCP, false)
 
 	// Send the columns metadata.
 	columnMetadata := b.createColMetadata()

--- a/net.go
+++ b/net.go
@@ -87,7 +87,7 @@ func (c *tlsHandshakeConn) Read(b []byte) (n int, err error) {
 			err = fmt.Errorf("Cannot read handshake packet: %s", err.Error())
 			return
 		}
-		if packet != packPrelogin {
+		if packet != PackPrelogin {
 			err = fmt.Errorf("unexpected packet %d, expecting prelogin", packet)
 			return
 		}
@@ -98,7 +98,7 @@ func (c *tlsHandshakeConn) Read(b []byte) (n int, err error) {
 
 func (c *tlsHandshakeConn) Write(b []byte) (n int, err error) {
 	if !c.packetPending {
-		c.buf.BeginPacket(packPrelogin, false)
+		c.buf.BeginPacket(PackPrelogin, false)
 		c.packetPending = true
 	}
 	return c.buf.Write(b)

--- a/rpc.go
+++ b/rpc.go
@@ -47,7 +47,7 @@ var (
 
 // http://msdn.microsoft.com/en-us/library/dd357576.aspx
 func sendRpc(buf *TdsBuffer, headers []headerStruct, proc procId, flags uint16, params []param, resetSession bool) (err error) {
-	buf.BeginPacket(packRPCRequest, resetSession)
+	buf.BeginPacket(PackRPCRequest, resetSession)
 	writeAllHeaders(buf, headers)
 	if len(proc.name) == 0 {
 		var idswitch uint16 = 0xffff

--- a/tds.go
+++ b/tds.go
@@ -154,10 +154,10 @@ func (p KeySlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // http://msdn.microsoft.com/en-us/library/dd357559.aspx
 func writePrelogin(w *TdsBuffer, fields map[uint8][]byte) error {
-	return writePreloginWithPacketType(w, fields, PackPrelogin)
+	return WritePreloginWithPacketType(w, fields, PackPrelogin)
 }
 
-func writePreloginWithPacketType(w *TdsBuffer, fields map[uint8][]byte, packetType packetType) error {
+func WritePreloginWithPacketType(w *TdsBuffer, fields map[uint8][]byte, packetType packetType) error {
 	var err error
 	w.BeginPacket(packetType, false)
 	offset := uint16(5*len(fields) + 1)
@@ -203,10 +203,10 @@ func writePreloginWithPacketType(w *TdsBuffer, fields map[uint8][]byte, packetTy
 }
 
 func readPrelogin(r *TdsBuffer) (map[uint8][]byte, error) {
-	return readPreloginWithPacketType(r, PackReply)
+	return ReadPreloginWithPacketType(r, PackReply)
 }
 
-func readPreloginWithPacketType(r *TdsBuffer, expectedPacketType packetType) (map[uint8][]byte, error) {
+func ReadPreloginWithPacketType(r *TdsBuffer, expectedPacketType packetType) (map[uint8][]byte, error) {
 	packet_type, err := r.BeginRead()
 	if err != nil {
 		return nil, err

--- a/token.go
+++ b/token.go
@@ -557,8 +557,8 @@ func processSingleResponse(sess *tdsSession, ch chan tokenStruct, outs map[strin
 		ch <- err
 		return
 	}
-	if packet_type != packReply {
-		badStreamPanic(fmt.Errorf("unexpected packet type in reply: got %v, expected %v", packet_type, packReply))
+	if packet_type != PackReply {
+		badStreamPanic(fmt.Errorf("unexpected packet type in reply: got %v, expected %v", packet_type, PackReply))
 	}
 	var columns []columnStruct
 	errs := make([]Error, 0, 5)

--- a/tran.go
+++ b/tran.go
@@ -29,7 +29,7 @@ const (
 )
 
 func sendBeginXact(buf *TdsBuffer, headers []headerStruct, isolation isoLevel, name string, resetSession bool) (err error) {
-	buf.BeginPacket(packTransMgrReq, resetSession)
+	buf.BeginPacket(PackTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmBeginXact
 	err = binary.Write(buf, binary.LittleEndian, &rqtype)
@@ -52,7 +52,7 @@ const (
 )
 
 func sendCommitXact(buf *TdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
-	buf.BeginPacket(packTransMgrReq, resetSession)
+	buf.BeginPacket(PackTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmCommitXact
 	err := binary.Write(buf, binary.LittleEndian, &rqtype)
@@ -81,7 +81,7 @@ func sendCommitXact(buf *TdsBuffer, headers []headerStruct, name string, flags u
 }
 
 func sendRollbackXact(buf *TdsBuffer, headers []headerStruct, name string, flags uint8, isolation uint8, newname string, resetSession bool) error {
-	buf.BeginPacket(packTransMgrReq, resetSession)
+	buf.BeginPacket(PackTransMgrReq, resetSession)
 	writeAllHeaders(buf, headers)
 	var rqtype uint16 = tmRollbackXact
 	err := binary.Write(buf, binary.LittleEndian, &rqtype)


### PR DESCRIPTION
The current go-mssqldb code acts as a client, and thus writes the PRELOGIN message to the server and reads the response from the server.

In the Secretless project we act as the target when communicating with the server so we want to read a PRELOGIN message from the client and write a PRELOGIN response to the client. 

This PR enables to read/write the PRELOGIN message to both sides.

Reviewers should start at `tds.go`. The main change is in `writePrelogin` & `readPrelogin` (in both cases I added another method that gets a packet type as a parameter).

As part of this commit, we also expose the packetType consts so they are
reachable from outside of the project (as they are needed to call the
new methods). all the rest of the changes are due to this refactor.