### PR TITLE
WIP - Expose Login Ack response details

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -157,6 +157,21 @@ func (c *Conn) NetConn() net.Conn {
 	return c.sess.buf.transport.(net.Conn)
 }
 
+// Returns the TDS version of the server
+func (c *Conn) TDSVersion() uint32 {
+	return c.sess.loginAck.TDSVersion
+}
+
+// Returns the name of the server (i.e Microsoft SQL Server)
+func (c *Conn) ProgName() string {
+	return c.sess.loginAck.ProgName
+}
+
+// Returns the version of the server
+func (c *Conn) ProgVer() uint32 {
+	return c.sess.loginAck.ProgVer
+}
+
 func (c *Conn) setReturnStatus(s ReturnStatus) {
 	if c.returnStatus == nil {
 		return


### PR DESCRIPTION
This is currently in WIP as we might won't need these details dynamically in Secretless

This PR exposes the following Ack response details:
- TDS version
- Server name (i.e Microsoft SQL Server)
- Server version

These details are part of the response we send to the client. Currently we send them hard-coded but we might need to send the actual details. In that case, we should merge this PR so these details are exposed.