### PR TITLE
Add an 'if' check to prevent null pointer exceptions

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -795,10 +795,6 @@ initiate_connection:
 		return nil, err
 	}
 
-	// This will panic will never occur unless our code is wrong
-	ch := ctx.Value("fields").(chan map[uint8][]byte)
-	ch <- fields
-
 	encryptBytes, ok := fields[PreloginENCRYPTION]
 	if !ok {
 		return nil, fmt.Errorf("Encrypt negotiation failed")
@@ -845,9 +841,14 @@ initiate_connection:
 		}
 	}
 
-	// Intercept prelogin resopnse and send to secretless
-	preLoginResponse := ctx.Value(ctxtypes.PreLoginResponseKey).(chan map[uint8][]byte)
-	preLoginResponse <- fields
+	// Intercept prelogin response and send to secretless
+	preLoginResponse := ctx.Value(ctxtypes.PreLoginResponseKey)
+
+	if preLoginResponse != nil {
+		// This will panic will never occur unless our code is wrong
+		preLoginResponse := preLoginResponse.(chan map[uint8][]byte)
+		preLoginResponse<- fields
+	}
 
 	login := login{
 		TDSVersion:   verTDS74,


### PR DESCRIPTION
If we test the mssql db plugin without secretless, no channel will
be passed in through the context. To avoid any issues testing the
plugin, we want to check here.