### PR TITLE
WIP: Secretless faithfully propagates MSSQL Login Response from server

### DIFF
--- a/connect_interceptor.go
+++ b/connect_interceptor.go
@@ -14,8 +14,6 @@ type ConnectInterceptor struct {
 	ServerPreLoginResponse chan map[uint8][]byte
 	// ClientLoginRequest is used to pass the client LoginRequest
 	ClientLoginRequest chan *LoginRequest
-	// ServerLoginResponse is used to pass the server LoginAck
-	ServerLoginResponse chan *LoginResponse
 }
 
 // NewConnectInterceptor is a constructor for a blank ConnectInterceptor
@@ -25,8 +23,6 @@ func NewConnectInterceptor() *ConnectInterceptor {
 		ServerPreLoginResponse: make(chan map[uint8][]byte),
 		// Create a channel for sending the client login to the driver through the context
 		ClientLoginRequest: make(chan *LoginRequest),
-		// Create a channel for receiving a server loginAck from the driver through the context
-		ServerLoginResponse: make(chan *LoginResponse),
 	}
 }
 


### PR DESCRIPTION
This change removes any handling and translation of login responses
from the server in the secretless broker. Instead, secretless will
now "call it a day" after sending a translated version of the client's
login request to the MSSQL server. Login responses from the server
will now be passed transparently (from the perspective of secretless)
from the server to the client.

This is a Work-in-Progress. There is one integration test that is
failing, and I need to do more investigation: The test for whether
secretless is faithfully passing a bad database name in a login
request from the client to the server is failing. In this scenario,
the server is sending a "Cannot open database" error, but the client
is somehow not detecting the error.

This pull request is the counterpart of PR #1110 for the secretless
broker repository.
