### PR TITLE
1165 - Support exists for sslmode=verify-ca

### DIFF
--- a/conn_str.go
+++ b/conn_str.go
@@ -26,6 +26,7 @@ type connectParams struct {
 	disableEncryption         bool
 	trustServerCertificate    bool
 	certificate               string
+	rawCertificate            string
 	hostInCertificate         string
 	hostInCertificateProvided bool
 	serverSPN                 string
@@ -171,6 +172,7 @@ func parseConnectParams(dsn string) (connectParams, error) {
 		}
 	}
 	p.certificate = params["certificate"]
+	p.rawCertificate = params["rawcertificate"]
 	p.hostInCertificate, ok = params["hostnameincertificate"]
 	if ok {
 		p.hostInCertificateProvided = true

--- a/tds.go
+++ b/tds.go
@@ -611,7 +611,7 @@ func ReadLoginRequest(_r io.ReadWriteCloser) (*LoginRequest, error) {
 	}
 
 	r.rpos = offsetAfterHeader(hdr.PasswordOffset)
-	passwordBytes := make([]byte, int(hdr.PasswordLength) * 2)
+	passwordBytes := make([]byte, int(hdr.PasswordLength)*2)
 	_, err = r.Read(passwordBytes)
 	if err != nil {
 		return nil, err
@@ -1125,6 +1125,10 @@ initiate_connection:
 			}
 			certs := x509.NewCertPool()
 			certs.AppendCertsFromPEM(pem)
+			config.RootCAs = certs
+		} else if len(p.rawCertificate) > 0 {
+			certs := x509.NewCertPool()
+			certs.AppendCertsFromPEM([]byte(p.rawCertificate))
 			config.RootCAs = certs
 		}
 		if p.trustServerCertificate {


### PR DESCRIPTION
sslmode=verify-ca dictates that TLS must be used between
Secretless and the target service. We've added the
 rawCertificate parameter to pass a certificate as a
string rather than a file reference.