### PR TITLE
Fix manual TLS verification to NOT verify hostname

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1155,7 +1155,6 @@ initiate_connection:
 
 			certs := tlsConn.ConnectionState().PeerCertificates
 			opts := x509.VerifyOptions{
-				DNSName:       tlsConn.ConnectionState().ServerName,
 				Intermediates: x509.NewCertPool(),
 				Roots:         config.RootCAs,
 			}


### PR DESCRIPTION
Use empty DNSName in x509.VerifyOptions for manual verification. For some reason we were using `tlsConn.ConnectionState().ServerName` as the DNSName before and it just happened to be empty all along (or just in the tests).

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
