### PR TITLE
Skip gosec enforcement on intentional TLS config

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1131,9 +1131,11 @@ initiate_connection:
 			certs.AppendCertsFromPEM([]byte(p.rawCertificate))
 			config.RootCAs = certs
 		}
+		/* #nosec */
 		if p.trustServerCertificate {
 			config.InsecureSkipVerify = true
 		}
+		/* #nosec */
 		if p.disableVerifyHostname {
 			config.InsecureSkipVerify = true
 		}


### PR DESCRIPTION
Gosec is warning about the usage of `config.InsecureSkipVerify = true` in other pipelines which use this submodule. Add an instruction to ignore intentional TLS config updates.
