### PR TITLE
CNJR-5372: Fix 'nosec' comments

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1131,13 +1131,11 @@ initiate_connection:
 			certs.AppendCertsFromPEM([]byte(p.rawCertificate))
 			config.RootCAs = certs
 		}
-		/* #nosec */
 		if p.trustServerCertificate {
-			config.InsecureSkipVerify = true
+			config.InsecureSkipVerify = true // #nosec
 		}
-		/* #nosec */
 		if p.disableVerifyHostname {
-			config.InsecureSkipVerify = true
+			config.InsecureSkipVerify = true // #nosec
 		}
 		config.ServerName = p.hostInCertificate
 		// fix for https://github.com/denisenkom/go-mssqldb/issues/166


### PR DESCRIPTION
### Desired Outcome

Gosec is now flagging statements that it apparently wasn't previously. This PR fixes the syntax of the relevant `nosec` comments.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: CNJR-5372

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
